### PR TITLE
Rewrote the "system_prop_check" to not give a type error in the AADL …

### DIFF
--- a/CASE_simple_example/AADL/claim.aadl
+++ b/CASE_simple_example/AADL/claim.aadl
@@ -48,7 +48,8 @@ package claim
     -- property for each component that contains AGREE contracts when those checks pass
     system_prop_checked(c : component, prop : string) <=
     	** "AGREE property passed: [ " prop " ]" **
-    	has_property(c, CASE::AGREE_PROPERTIES_PASSED) and length(intersect(property(c, CASE::AGREE_PROPERTIES_PASSED), {prop})) = 1
+        has_property(c, CASE::AGREE_PROPERTIES_PASSED) and
+        member(prop, property(c, CASE::AGREE_PROPERTIES_PASSED))
 
 	-- Checks if the specified component is a filter
 	is_filter(c : component) : bool =


### PR DESCRIPTION
Issac,

I rewrote the "system_prop_checked" claim in claim.aadl to not have a type error in the OSATE AADL editor. I believe the rewrite is equivalent to the original claim. Let me know.

egm