### PR TITLE
Increase seL4 docker revision to fix setuptools

### DIFF
--- a/TA5/case-env/case-setup.sh
+++ b/TA5/case-env/case-setup.sh
@@ -7,7 +7,7 @@ set -Eeuxo pipefail
 : "${GIT_USER:=Snail}"
 : "${GIT_EMAIL:=<>}"
 
-: "${SEL4_SCRIPTS_V:=728539476ada9263a3ce57370bf842fd32f6987c}"
+: "${SEL4_SCRIPTS_V:=592fb0c03c9727dd37e24b2e9b0a17d541c25388}"
 : "${SEL4_V:=28831f579e3560bd3aa18a3898505f091d66b076}"
 : "${CAMKES_V:=e7f5c6da03fc8a71a5a2e503de9f9004acf3ef2a}"
 : "${SIREUM_V:=8787cf0}"


### PR DESCRIPTION
Fixes vagrant script error where python tools cannot be built due to inconsistent setuptools installation.